### PR TITLE
Differentiate between client and server generated events

### DIFF
--- a/lib/modules/storage/meteor_methods/class_insert.js
+++ b/lib/modules/storage/meteor_methods/class_insert.js
@@ -1,5 +1,5 @@
 let methods = Astro.Module.modules.storage.meteorMethods;
 
 methods['/Astronomy/classInsert'] = function(className, values) {
-  return Astro.utils.storage.classInsert(className, values);
+  return Astro.utils.storage.classInsert(className, values, true);
 };

--- a/lib/modules/storage/meteor_methods/class_remove.js
+++ b/lib/modules/storage/meteor_methods/class_remove.js
@@ -1,5 +1,5 @@
 let methods = Astro.Module.modules.storage.meteorMethods;
 
 methods['/Astronomy/classRemove'] = function(className, selector) {
-  return Astro.utils.storage.classRemove(className, selector);
+  return Astro.utils.storage.classRemove(className, selector, true);
 };

--- a/lib/modules/storage/meteor_methods/class_update.js
+++ b/lib/modules/storage/meteor_methods/class_update.js
@@ -4,6 +4,6 @@ methods['/Astronomy/classUpdate'] = function(
   className, selector, modifier, options
 ) {
   return Astro.utils.storage.classUpdate(
-    className, selector, modifier, options
+    className, selector, modifier, options, true
   );
 };

--- a/lib/modules/storage/meteor_methods/document_insert.js
+++ b/lib/modules/storage/meteor_methods/document_insert.js
@@ -1,5 +1,5 @@
 let methods = Astro.Module.modules.storage.meteorMethods;
 
 methods['/Astronomy/documentInsert'] = function(doc) {
-  return Astro.utils.storage.documentInsert(doc);
+  return Astro.utils.storage.documentInsert(doc, true);
 };

--- a/lib/modules/storage/meteor_methods/document_remove.js
+++ b/lib/modules/storage/meteor_methods/document_remove.js
@@ -1,5 +1,5 @@
 let methods = Astro.Module.modules.storage.meteorMethods;
 
 methods['/Astronomy/documentRemove'] = function(doc) {
-  return Astro.utils.storage.documentRemove(doc);
+  return Astro.utils.storage.documentRemove(doc, true);
 };

--- a/lib/modules/storage/meteor_methods/document_update.js
+++ b/lib/modules/storage/meteor_methods/document_update.js
@@ -1,5 +1,5 @@
 let methods = Astro.Module.modules.storage.meteorMethods;
 
 methods['/Astronomy/documentUpdate'] = function(doc) {
-  return Astro.utils.storage.documentUpdate(doc);
+  return Astro.utils.storage.documentUpdate(doc, true);
 };

--- a/lib/modules/storage/utils/class_insert.js
+++ b/lib/modules/storage/utils/class_insert.js
@@ -1,4 +1,4 @@
-Astro.utils.storage.classInsert = function(className, doc) {
+Astro.utils.storage.classInsert = function(className, doc, untrusted) {
   let Class = Astro.Class.get(className);
   let Collection = Class.getCollection();
 
@@ -15,7 +15,7 @@ Astro.utils.storage.classInsert = function(className, doc) {
 
   // Trigger the "beforeSave" event handlers.
   if (!doc.dispatchEvent(new Astro.Event('beforeSave', {
-    cancelable: true, propagates: true
+    cancelable: true, propagates: true, trusted: !untrusted
   }))) {
     // If an event was prevented, then we stop here.
     throw new Meteor.Error('prevented', 'Operation prevented', {
@@ -24,7 +24,7 @@ Astro.utils.storage.classInsert = function(className, doc) {
   }
   // Trigger the "beforeInsert" event handlers.
   if (!doc.dispatchEvent(new Astro.Event('beforeInsert', {
-    cancelable: true, propagates: true
+    cancelable: true, propagates: true, trusted: !untrusted
   }))) {
     // If an event was prevented, then we stop here.
     throw new Meteor.Error('prevented', 'Operation prevented', {
@@ -52,11 +52,11 @@ Astro.utils.storage.classInsert = function(className, doc) {
 
   // Trigger the "afterInsert" event handlers.
   doc.dispatchEvent(new Astro.Event('afterInsert', {
-    propagates: true
+    propagates: true, trusted: !untrusted
   }));
   // Trigger the "afterSave" event handlers.
   doc.dispatchEvent(new Astro.Event('afterSave', {
-    propagates: true
+    propagates: true, trusted: !untrusted
   }));
 
   return result;

--- a/lib/modules/storage/utils/class_remove.js
+++ b/lib/modules/storage/utils/class_remove.js
@@ -1,4 +1,4 @@
-Astro.utils.storage.classRemove = function(className, selector) {
+Astro.utils.storage.classRemove = function(className, selector, untrusted) {
   let Class = Astro.Class.get(className);
   let Collection = Class.getCollection();
 
@@ -11,7 +11,7 @@ Astro.utils.storage.classRemove = function(className, selector) {
   docs.forEach(function(doc) {
     // Trigger the "beforeRemove" event handlers.
     if (!doc.dispatchEvent(new Astro.Event('beforeRemove', {
-      cancelable: true, propagates: true
+      cancelable: true, propagates: true, trusted: !untrusted
     }))) {
       // If an event was prevented, then we stop here.
       throw new Meteor.Error('prevented', 'Operation prevented', {
@@ -27,7 +27,7 @@ Astro.utils.storage.classRemove = function(className, selector) {
 
     // Trigger the "afterRemove" event handlers.
     doc.dispatchEvent(new Astro.Event('afterRemove', {
-      propagates: true
+      propagates: true, trusted: !untrusted
     }));
   });
 

--- a/lib/modules/storage/utils/class_update.js
+++ b/lib/modules/storage/utils/class_update.js
@@ -1,5 +1,5 @@
 Astro.utils.storage.classUpdate = function(
-  className, selector, modifier, options
+  className, selector, modifier, options, untrusted
 ) {
   let Class = Astro.Class.get(className);
   let Collection = Class.getCollection();
@@ -20,7 +20,7 @@ Astro.utils.storage.classUpdate = function(
 
     // Trigger the "beforeSave" event handlers.
     if (!doc.dispatchEvent(new Astro.Event('beforeSave', {
-      cancelable: true, propagates: true
+      cancelable: true, propagates: true, trusted: !untrusted
     }))) {
       // If an event was prevented, then we stop here.
       throw new Meteor.Error('prevented', 'Operation prevented', {
@@ -29,7 +29,7 @@ Astro.utils.storage.classUpdate = function(
     }
     // Trigger the "beforeUpdate" event handlers.
     if (!doc.dispatchEvent(new Astro.Event('beforeUpdate', {
-      cancelable: true, propagates: true
+      cancelable: true, propagates: true, trusted: !untrusted
     }))) {
       // If an event was prevented, then we stop here.
       throw new Meteor.Error('prevented', 'Operation prevented', {
@@ -55,11 +55,11 @@ Astro.utils.storage.classUpdate = function(
 
     // Trigger the "afterUpdate" event handlers.
     doc.dispatchEvent(new Astro.Event('afterUpdate', {
-      propagates: true
+      propagates: true, trusted: !untrusted
     }));
     // Trigger the "afterSave" event handlers.
     doc.dispatchEvent(new Astro.Event('afterSave', {
-      propagates: true
+      propagates: true, trusted: !untrusted
     }));
   });
 

--- a/lib/modules/storage/utils/document_insert.js
+++ b/lib/modules/storage/utils/document_insert.js
@@ -1,4 +1,4 @@
-Astro.utils.storage.documentInsert = function(doc) {
+Astro.utils.storage.documentInsert = function(doc, untrusted) {
   let Class = doc.constructor;
   let Collection = Class.getCollection();
 
@@ -12,7 +12,7 @@ Astro.utils.storage.documentInsert = function(doc) {
 
   // Trigger the "beforeSave" event handlers.
   if (!doc.dispatchEvent(new Astro.Event('beforeSave', {
-    cancelable: true, propagates: true
+    cancelable: true, propagates: true, trusted: !untrusted
   }))) {
     // If an event was prevented, then we stop here.
     throw new Meteor.Error('prevented', 'Operation prevented', {
@@ -21,7 +21,7 @@ Astro.utils.storage.documentInsert = function(doc) {
   }
   // Trigger the "beforeInsert" event handlers.
   if (!doc.dispatchEvent(new Astro.Event('beforeInsert', {
-    cancelable: true, propagates: true
+    cancelable: true, propagates: true, trusted: !untrusted
   }))) {
     // If an event was prevented, then we stop here.
     throw new Meteor.Error('prevented', 'Operation prevented', {
@@ -49,11 +49,11 @@ Astro.utils.storage.documentInsert = function(doc) {
 
   // Trigger the "afterInsert" event handlers.
   doc.dispatchEvent(new Astro.Event('afterInsert', {
-    propagates: true
+    propagates: true, trusted: !untrusted
   }));
   // Trigger the "afterSave" event handlers.
   doc.dispatchEvent(new Astro.Event('afterSave', {
-    propagates: true
+    propagates: true, trusted: !untrusted
   }));
 
   return result;

--- a/lib/modules/storage/utils/document_remove.js
+++ b/lib/modules/storage/utils/document_remove.js
@@ -1,4 +1,4 @@
-Astro.utils.storage.documentRemove = function(doc) {
+Astro.utils.storage.documentRemove = function(doc, untrusted) {
   let Class = doc.constructor;
   let Collection = Class.getCollection();
 
@@ -12,7 +12,7 @@ Astro.utils.storage.documentRemove = function(doc) {
 
   // Trigger the "beforeRemove" event handlers.
   if (!doc.dispatchEvent(new Astro.Event('beforeRemove', {
-    cancelable: true, propagates: true
+    cancelable: true, propagates: true, trusted: !untrusted
   }))) {
     // If an event was prevented, then we stop here.
     throw new Meteor.Error('prevented', 'Operation prevented', {
@@ -27,7 +27,7 @@ Astro.utils.storage.documentRemove = function(doc) {
 
   // Trigger the "afterRemove" event handlers.
   doc.dispatchEvent(new Astro.Event('afterRemove', {
-    propagates: true
+    propagates: true, trusted: !untrusted
   }));
 
   return result;

--- a/lib/modules/storage/utils/document_update.js
+++ b/lib/modules/storage/utils/document_update.js
@@ -1,4 +1,4 @@
-Astro.utils.storage.documentUpdate = function(doc) {
+Astro.utils.storage.documentUpdate = function(doc, untrusted) {
   let Class = doc.constructor;
   let Collection = Class.getCollection();
 
@@ -7,7 +7,7 @@ Astro.utils.storage.documentUpdate = function(doc) {
 
   // Trigger the "beforeSave" event handlers.
   if (!doc.dispatchEvent(new Astro.Event('beforeSave', {
-    cancelable: true, propagates: true
+    cancelable: true, propagates: true, trusted: !untrusted
   }))) {
     // If an event was prevented, then we stop here.
     throw new Meteor.Error('prevented', 'Operation prevented', {
@@ -16,7 +16,7 @@ Astro.utils.storage.documentUpdate = function(doc) {
   }
   // Trigger the "beforeUpdate" event handlers.
   if (!doc.dispatchEvent(new Astro.Event('beforeUpdate', {
-    cancelable: true, propagates: true
+    cancelable: true, propagates: true, trusted: !untrusted
   }))) {
     // If an event was prevented, then we stop here.
     throw new Meteor.Error('prevented', 'Operation prevented', {
@@ -43,11 +43,11 @@ Astro.utils.storage.documentUpdate = function(doc) {
 
   // Trigger the "afterUpdate" event handlers.
   doc.dispatchEvent(new Astro.Event('afterUpdate', {
-    propagates: true
+    propagates: true, trusted: !untrusted
   }));
   // Trigger the "afterSave" event handlers.
   doc.dispatchEvent(new Astro.Event('afterSave', {
-    propagates: true
+    propagates: true, trusted: !untrusted
   }));
 
   return result;


### PR DESCRIPTION
Adds an `e.trusted` flag to events to differentiate between client or server generated operations.
